### PR TITLE
Updated to fix build errors when using go-sdl2 v0.3.0 and go v1.13.5

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,15 +26,16 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/binary"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"math"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"runtime"
 	"time"
-	"unsafe"
 
 	"github.com/massung/CHIP-8/chip8"
 	"github.com/sqweek/dialog"
@@ -231,10 +232,14 @@ func setIcon() {
 
 		// decompress all the bytes
 		if icon, err := ioutil.ReadAll(gz); err == nil {
-			rw := sdl.RWFromMem(unsafe.Pointer(&icon[0]), len(icon))
+			rw, err := sdl.RWFromMem(icon)
+
+			if errors.Is(err, os.ErrExist) {
+				panic(err)
+			}
 
 			// read the bitmap data and create the icon surface
-			if surface, err := sdl.LoadBMPRW(rw, 1); err == nil {
+			if surface, err := sdl.LoadBMPRW(rw, true); err == nil {
 				Window.SetIcon(surface)
 			}
 		}
@@ -302,7 +307,7 @@ func loadFont() {
 	mask := sdl.MapRGB(surface.Format, 255, 0, 255)
 
 	// set the mask color key
-	surface.SetColorKey(1, mask)
+	surface.SetColorKey(true, mask)
 
 	// create the texture
 	if Font, err = Renderer.CreateTextureFromSurface(surface); err != nil {


### PR DESCRIPTION
Since the last update go-sdl2 has changed its api slightly and so I fix the errors to allow for a successful build